### PR TITLE
Get run ID with shell script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,22 @@ jobs:
         with:
           path: artifacts
 
+      - name: Get Run ID
+        id: get_run_id
+        run: |
+          echo "::set-output name=run_id::$(\
+            gh run list \
+              --workflow \"${{ github.event.pull_request.base.ref == 'main' && 'default-branch.yml' || 'main.yml' }}\" \
+              --json conclusion,headSha,status,databaseId \
+              --jq ".[] | select( .conclusion == \"success\" and .headSha == \"${{github.event.pull_request.base.sha}}\") | .databaseId" \
+          )"
+
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         continue-on-error: true
         with:
           workflow: ${{ github.event.pull_request.base.ref == 'main' && 'default-branch.yml' || 'main.yml' }}
-          workflow_conclusion: success
-          commit: ${{github.event.pull_request.base.sha}}
+          run_id: ${{steps.get_run_id.run_id}}
           name: 'test-coverage-output'
           path: base-artifacts
           search_artifacts: 'test-coverage-output'


### PR DESCRIPTION
Run IDs greater than Java's max integer value are not found using GitHub REST APIs used in https://github.com/dawidd6/action-download-artifact/issues/147. 

Fetching run id using GitHub CLI.