### PR TITLE
Deprecating set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,12 @@ jobs:
       - name: Get Run ID
         id: get_run_id
         run: |
-          echo "::set-output name=run_id::$(\
+          echo "run_id=$(\
             gh run list \
               --workflow "${{ github.event.pull_request.base.ref == 'main' && 'default-branch.yml' || 'main.yml' }}" \
               --json conclusion,headSha,status,databaseId \
               --jq ".[] | select( .conclusion == \"success\" and .headSha == \"${{github.event.pull_request.base.sha}}\") | .databaseId" \
-          )"
+          )" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
Per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/