### PR TITLE
Fix comparison with base branch

### DIFF
--- a/.github/workflows/base-update.yml
+++ b/.github/workflows/base-update.yml
@@ -18,7 +18,7 @@ jobs:
         run: git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1000
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2.24.2
         continue-on-error: true
         with:
           workflow: ${{ github.event.pull_request.base.ref == 'main' && 'default-branch.yml' || 'main.yml' }}
@@ -29,7 +29,7 @@ jobs:
           search_artifacts: 'test-coverage-output'
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2.24.2
         continue-on-error: true
         with:
           workflow: 'main.yml'

--- a/.github/workflows/base-update.yml
+++ b/.github/workflows/base-update.yml
@@ -26,7 +26,7 @@ jobs:
           commit: ${{github.event.pull_request.base.sha}}
           name: 'test-coverage-output'
           path: base-artifacts
-          search_artifacts: 'test-coverage-output'
+          search_artifacts: true
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2.24.2
@@ -37,7 +37,7 @@ jobs:
           commit: ${{github.event.pull_request.head.sha}}
           name: 'test-coverage-output'
           path: artifacts
-          search_artifacts: 'test-coverage-output'
+          search_artifacts: true
 
       - name: Check file existence
         id: check_files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
           run_id: ${{steps.get_run_id.outputs.run_id}}
           name: 'test-coverage-output'
           path: base-artifacts
-          search_artifacts: 'test-coverage-output'
+          search_artifacts: true
 
       - name: Check file existence
         id: check_files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2.24.2
         continue-on-error: true
         with:
           workflow: ${{ github.event.pull_request.base.ref == 'main' && 'default-branch.yml' || 'main.yml' }}

--- a/comment-template.svelte
+++ b/comment-template.svelte
@@ -26,34 +26,43 @@
       type: 'Total Statements Coverage',
       percent: {
         total: total_statements_coverage_percent_raw,
-        base: has_base_data ? base_total_statements_coverage_percent_raw: null,
-        diff: has_base_data ? (total_statements_coverage_percent_raw - base_total_statements_coverage_percent_raw) : null,
-      }
+        base: has_base_data ? base_total_statements_coverage_percent_raw : null,
+        diff: has_base_data
+          ? total_statements_coverage_percent_raw - base_total_statements_coverage_percent_raw
+          : null,
+      },
     },
     {
       type: 'Total Branches Coverage',
       percent: {
         total: total_branches_coverage_percent_raw,
-        base: has_base_data ? base_total_branches_coverage_percent_raw: null,
-        diff: has_base_data ? (total_branches_coverage_percent_raw - base_total_branches_coverage_percent_raw) : null,
-      }
+        base: has_base_data ? base_total_branches_coverage_percent_raw : null,
+        diff: has_base_data
+          ? total_branches_coverage_percent_raw - base_total_branches_coverage_percent_raw
+          : null,
+      },
     },
     {
       type: 'Total Functions Coverage',
       percent: {
         total: total_functions_coverage_percent_raw,
-        base: has_base_data ? base_total_functions_coverage_percent_raw: null,
-        diff: has_base_data ? (total_functions_coverage_percent_raw - base_total_functions_coverage_percent_raw) : null,
-      }
+        base: has_base_data ? base_total_functions_coverage_percent_raw : null,
+        diff: has_base_data
+          ? total_functions_coverage_percent_raw - base_total_functions_coverage_percent_raw
+          : null,
+      },
     },
     {
       type: 'Total Lines Coverage',
       percent: {
         total: total_lines_coverage_percent_raw,
-        base: has_base_data ? base_total_lines_coverage_percent_raw: null,
-        diff: has_base_data ? (total_lines_coverage_percent_raw - base_total_lines_coverage_percent_raw) : null,
-      }
-    }];
+        base: has_base_data ? base_total_lines_coverage_percent_raw : null,
+        diff: has_base_data
+          ? total_lines_coverage_percent_raw - base_total_lines_coverage_percent_raw
+          : null,
+      },
+    },
+  ];
 
   const LETTER_LABEL = {
     S: 'Statements',
@@ -101,25 +110,29 @@
 
 <h2>Coverage Report</h2>
 
-Commit: <a href="{commit_link}">{short_commit_sha}</a><br>
-Base: <a href="{base_commit_link}">{base_ref}@{base_short_commit_sha}</a><br><br>
+Commit:<a href={commit_link}>{short_commit_sha}</a><br />
+Base: <a href={base_commit_link}>{base_ref}@{base_short_commit_sha}</a><br /><br />
+
+```json
+{JSON.stringify($$props, null, 2)}
+```
 
 <table>
   <thead>
     <th>Type</th>
-      {#if has_base_data}
-        <th>Base</th>
-      {/if}
+    {#if has_base_data}
+      <th>Base</th>
+    {/if}
     <th>This PR</th>
   </thead>
   <tbody>
-    {#each summary_list as {type, percent}}
+    {#each summary_list as { type, percent }}
       <tr>
         <td>{type}</td>
         {#if has_base_data}
           <td>
             {#if Number.isFinite(percent.base)}
-              <img src="{getCoverageLevelImage(percent.base)}" alt="">&nbsp;{percent.base}%
+              <img src={getCoverageLevelImage(percent.base)} alt="" />&nbsp;{percent.base}%
             {:else}
               -
             {/if}
@@ -127,7 +140,7 @@ Base: <a href="{base_commit_link}">{base_ref}@{base_short_commit_sha}</a><br><br
         {/if}
         <td>
           {#if Number.isFinite(percent.total)}
-            <img src="{getCoverageLevelImage(percent.total)}" alt="">&nbsp;{percent.total}%
+            <img src={getCoverageLevelImage(percent.total)} alt="" />&nbsp;{percent.total}%
             {#if has_base_data}
               &nbsp;({formatPercentDiff(percent.diff)})
             {/if}
@@ -141,7 +154,7 @@ Base: <a href="{base_commit_link}">{base_ref}@{base_short_commit_sha}</a><br><br
 </table>
 
 <details>
-  <summary>Details (changed files):</summary><br>
+  <summary>Details (changed files):</summary><br />
   <table>
     <thead>
       <th>File</th>
@@ -156,7 +169,7 @@ Base: <a href="{base_commit_link}">{base_ref}@{base_short_commit_sha}</a><br><br
           data.statements.pct,
           data.branches.pct,
           data.functions.pct,
-          data.lines.pct
+          data.lines.pct,
         ]}
         <tr>
           <td>
@@ -165,7 +178,7 @@ Base: <a href="{base_commit_link}">{base_ref}@{base_short_commit_sha}</a><br><br
           {#each percents as percent}
             <td>
               {#if Number.isFinite(percent)}
-                <img src="{getCoverageLevelImage(percent)}" alt="">&nbsp;{percent}%
+                <img src={getCoverageLevelImage(percent)} alt="" />&nbsp;{percent}%
               {:else}
                 -
               {/if}

--- a/comment-template.svelte
+++ b/comment-template.svelte
@@ -113,10 +113,6 @@
 Commit:<a href={commit_link}>{short_commit_sha}</a><br />
 Base: <a href={base_commit_link}>{base_ref}@{base_short_commit_sha}</a><br /><br />
 
-```json
-{JSON.stringify($$props, null, 2)}
-```
-
 <table>
   <thead>
     <th>Type</th>

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,6 @@ async function run() {
     [ActionOutput.base_ref]: `${github.context.payload.pull_request.base.ref}`,
   };
 
-  console.log('outputs', outputs);
-
   const commentTemplateFilePath = path.resolve(core.getInput(ActionInput.comment_template_file));
   const commentMark = `<!-- ${DEFAULT_COMMENT_MARKER} -->`;
 

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,8 @@ async function run() {
     [ActionOutput.base_ref]: `${github.context.payload.pull_request.base.ref}`,
   };
 
+  console.log('outputs', outputs);
+
   const commentTemplateFilePath = path.resolve(core.getInput(ActionInput.comment_template_file));
   const commentMark = `<!-- ${DEFAULT_COMMENT_MARKER} -->`;
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -8,10 +8,7 @@ t.test('replaceTokens', async () => {
     '1, 2, and 3',
   );
 
-  // t.throws(
-  //   function throwsErrorForMissingToken() {
-  //     replaceTokens('{{one}}, {{four}}, and {{five}}', { one: 1, two: 2, three: 3 });
-  //   },
-  //   new Error('Invalid or missing tokens: four,five')
-  // );
+  t.throws(function throwsErrorForMissingToken() {
+    replaceTokens('{{one}}, {{four}}, and {{five}}', { one: 1, two: 2, three: 3 });
+  }, new Error('Invalid or missing tokens: four,five'));
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -8,10 +8,10 @@ t.test('replaceTokens', async () => {
     '1, 2, and 3',
   );
 
-  t.throws(
-    function throwsErrorForMissingToken() {
-      replaceTokens('{{one}}, {{four}}, and {{five}}', { one: 1, two: 2, three: 3 });
-    },
-    new Error('Invalid or missing tokens: four,five')
-  );
+  // t.throws(
+  //   function throwsErrorForMissingToken() {
+  //     replaceTokens('{{one}}, {{four}}, and {{five}}', { one: 1, two: 2, three: 3 });
+  //   },
+  //   new Error('Invalid or missing tokens: four,five')
+  // );
 });


### PR DESCRIPTION
As reported in https://github.com/sidx1024/report-nyc-coverage-github-action/issues/36, the comment didn't show comparison with base because the option `search_artifacts` was changed to be a boolean by the github action `dawidd6/action-download-artifact@v2.24.2`.